### PR TITLE
Merge multiple parameter adjustments support from upstream

### DIFF
--- a/sunspot/lib/sunspot/dsl/adjustable.rb
+++ b/sunspot/lib/sunspot/dsl/adjustable.rb
@@ -26,9 +26,9 @@ module Sunspot
       #       params["mlt.match.include"] = true
       #     end
       #   end
-      # 
+      #
       def adjust_solr_params( &block )
-        @query.solr_parameter_adjustment = block
+        @query.add_parameter_adjustment(block)
       end
 
       #

--- a/sunspot/lib/sunspot/query/common_query.rb
+++ b/sunspot/lib/sunspot/query/common_query.rb
@@ -12,11 +12,11 @@ module Sunspot
         end
 
         @pagination = nil
-        @parameter_adjustment = nil
+        @parameter_adjustments = []
       end
 
-      def solr_parameter_adjustment=(block)
-        @parameter_adjustment = block
+      def add_parameter_adjustment(block)
+        @parameter_adjustments << block
       end
 
       def add_sort(sort)
@@ -76,7 +76,11 @@ module Sunspot
         @components.each do |component|
           Sunspot::Util.deep_merge!(params, component.to_params)
         end
-        @parameter_adjustment.call(params) if @parameter_adjustment
+
+        @parameter_adjustments.each do |_block|
+          _block.call(params)
+        end
+
         params[:q] ||= '*:*'
         params
       end

--- a/sunspot/spec/api/query/more_like_this_spec.rb
+++ b/sunspot/spec/api/query/more_like_this_spec.rb
@@ -132,6 +132,19 @@ describe 'more_like_this' do
     connection.should have_last_search_with(:some => 'param')
   end
 
+  it "should send query to solr with adjusted parameters in multiple blocks" do
+    session.more_like_this(Post.new) do
+      adjust_solr_params do |params|
+        params[:q]    = 'new search'
+      end
+      adjust_solr_params do |params|
+        params[:some] = 'param'
+      end
+    end
+    connection.should have_last_search_with(:q    => 'new search')
+    connection.should have_last_search_with(:some => 'param')
+  end
+
   private
 
   def search(*args, &block)


### PR DESCRIPTION
I was looking at `JobSearcher` class in Jobengine in searching for refactoring ideas and found this comment:

> We need to do everything here because adjust_solr_params can only be called once

https://github.com/jobseekerltd/jobengine/blob/master/lib/search/job_searcher.rb#L279

Since our sunspot version is left behind a bit, I did a quick search in the upstream repo and found these commits that fix the limitation. Hopefully this can get merged so that we can break the method into more logical pieces.