### PR TITLE
Add `query_time` to `Sunspot::Rails::StubSessionProxy::Search`.

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
+++ b/sunspot_rails/lib/sunspot/rails/stub_session_proxy.rb
@@ -90,6 +90,10 @@ module Sunspot
           0
         end
 
+        def query_time
+          0
+        end
+
         def facets
           []
         end

--- a/sunspot_rails/spec/stub_session_proxy_spec.rb
+++ b/sunspot_rails/spec/stub_session_proxy_spec.rb
@@ -129,6 +129,10 @@ describe 'specs with Sunspot stubbed' do
       @search.total.should == 0
     end
 
+    it 'should return zero query_time' do
+      @search.query_time.should == 0
+    end
+
     it 'should return empty results for a given facet' do
       @search.facet(:category_id).rows.should == []
     end


### PR DESCRIPTION
`query_time` was added to `AbstractSearch` in https://github.com/sunspot/sunspot/pull/121, but was not added to `Sunspot::Rails::StubSessionProxy::Search`. This causes errors in controller tests where the stubbed search object is used.