### PR TITLE
Allow some control characters when filtering values.

### DIFF
--- a/sunspot/lib/sunspot/data_extractor.rb
+++ b/sunspot/lib/sunspot/data_extractor.rb
@@ -58,7 +58,7 @@ module Sunspot
 
       def strip_control_characters(value)
         if value.is_a? String
-          value.gsub(/[[:cntrl:]]/, ' ')
+          value.gsub(/[^[:print:]\r\n]/, ' ')
         elsif value.is_a? Array
           value.map { |v| strip_control_characters(v) }
         else


### PR DESCRIPTION
Related issues:
https://github.com/jobseekerltd/sunspot/pull/5 (also see the upstream issue)

Change made for the issue break some of Jobengine's functionality.
I want to allow some control characters to as a quick short-term solution.
A proper investigation and implementation are required.